### PR TITLE
Bumped deps to work with 1.9, including new freactive.core

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,14 @@
-(defproject fx-clj "0.2.0-alpha1"
+(defproject fx-clj "0.2.1-SNAPSHOT"
   :description "A Clojure library for JavaFX"
   :url "https://github.com/aaronc/fx-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-alpha3"]
-                 [org.clojure/core.async "0.1.338.0-5c5012-alpha"]
-                 [garden "1.2.1"]
-                 [potemkin "0.3.8"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474"]
+                 [garden "1.3.5"]
+                 [potemkin "0.4.5"]
                  [org.tobereplaced/lettercase "1.0.0"]
-                 [freactive.core "0.2.0-alpha1"]]
+                 [freactive.core "0.2.1-SNAPSHOT"]]
   :java-source-paths ["src"]
   :javac-options ["-Xlint:unchecked"]
   :profiles


### PR DESCRIPTION
Trying to dust this off to support some incanter development.

Turns out a lot of stuff is incompatible with 1.9.  So I fixed that.
Namely, getting rid of potemkin dep (only pulling in code for import-vars). 

Tests pass, demo works on mine.

I bumped this to 0.2.1-SNAPSHOT.